### PR TITLE
Update 'description' metadata

### DIFF
--- a/altspace-vr/index.yml
+++ b/altspace-vr/index.yml
@@ -7,7 +7,7 @@ brand: windows
 
 metadata:
   title: Welcome to AltspaceVR! # Required; page title displayed in search results. Include the brand. < 60 chars.
-  description: description # Required; article description that is displayed in search results. < 160 chars.
+  description: Explore the expanding world of VR events with AltspaceVR. # Required; article description that is displayed in search results. < 160 chars.
   services: mixed-reality 
   ms.service: mixed-reality #Required; service per approved list. service slug assigned to your service by ACOM.
   ms.topic: hub-page # Required


### PR DESCRIPTION
Updated description metatag to match the current value of the summary metatag.

The current default value, the string literal 'description', appears in social media cards:

![image](https://user-images.githubusercontent.com/52220496/112916703-f04d2500-90b5-11eb-8cba-9ed6ed1e4715.png)
